### PR TITLE
fix: added fingerprint verification logic

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Output       string
 	client       *http.Client
 	fingerprints []Fingerprint
+	skipfingerprints []Fingerprint
 }
 
 func (s *Config) initHTTPClient() {
@@ -36,10 +37,11 @@ func (s *Config) initHTTPClient() {
 }
 
 func (c *Config) loadFingerprints() error {
-	fingerprints, err := Fingerprints()
+	validFingerprints, skippedFingerprints, err := Fingerprints()
 	if err != nil {
 		return err
 	}
-	c.fingerprints = fingerprints
+	c.skipfingerprints = skippedFingerprints
+	c.fingerprints = validFingerprints
 	return nil
 }

--- a/runner/fingerprints.go
+++ b/runner/fingerprints.go
@@ -15,23 +15,34 @@ type Fingerprint struct {
 	False_Positive 		[]string
 }
 
-func Fingerprints() ([]Fingerprint, error) {
+func Fingerprints() ([]Fingerprint, []Fingerprint, error) {
 
-	var fingerprints []Fingerprint
+	var allFingerprints []Fingerprint
+	var validFingerprints []Fingerprint
+	var skippedFingerprints []Fingerprint
 
 	fingerPrintsPath, err := GetFingerprintPath()
 	if err != nil {
-		return nil, fmt.Errorf("Fingerprints: %v", err)
+		return nil, nil, fmt.Errorf("Fingerprints: %v", err)
 	}
 	file, err := os.ReadFile(fingerPrintsPath)
 	if err != nil {
-		return nil, fmt.Errorf("Fingerprints: %v", err)
+		return nil, nil, fmt.Errorf("Fingerprints: %v", err)
 	}
 
-	err = json.Unmarshal(file, &fingerprints)
+	err = json.Unmarshal(file, &allFingerprints)
 	if err != nil {
-		return nil, fmt.Errorf("Fingerprints: %v", err)
+		return nil, nil, fmt.Errorf("Fingerprints: %v", err)
 	}
 
-	return fingerprints, nil
+	for _, fingerprint := range allFingerprints {
+		if fingerprint.Fingerprint == "" {
+			skippedFingerprints = append(skippedFingerprints, fingerprint)
+		} else {
+			validFingerprints = append(validFingerprints, fingerprint)
+		}
+	}
+
+
+	return validFingerprints, skippedFingerprints, err
 }

--- a/runner/process.go
+++ b/runner/process.go
@@ -13,7 +13,7 @@ import (
 
 func Process(config *Config) error {
 
-	fingerprints, err := Fingerprints()
+	validFingerprints, skippedFingerprints, err := Fingerprints()
 	if err != nil {
 		return fmt.Errorf("Process: %v", err)
 	}
@@ -22,8 +22,22 @@ func Process(config *Config) error {
 	config.loadFingerprints()
 	subdomains := getSubdomains(config)
 
-	fmt.Println("[ * ]", "Loaded", len(subdomains), "targets")
-	fmt.Println("[ * ]", "Loaded", len(fingerprints), "fingerprints")
+	fmt.Println("[ * ]", "Loaded", len(subdomains), "Targets")
+	fmt.Println("[ * ]", "Loaded", len(validFingerprints), "Valid Fingerprints")
+	fmt.Println("[ * ]", "Skipped", len(skippedFingerprints), "Due to Invalid or Empty Fingerprints")
+	
+	// Collecting the names of skipped fingerprints for debug and skipped test
+
+	var skippedFingerprintNames []string
+	for _, fingerprint := range skippedFingerprints {
+		skippedFingerprintNames = append(skippedFingerprintNames, fingerprint.Engine) // Print only Engine Name
+	}
+	skippedFingerprintNamesStr := strings.Join(skippedFingerprintNames, ", ")
+	fmt.Println("[ * ] Skipped Fingerprints:", skippedFingerprintNamesStr)
+
+
+
+
 	if config.Output != "" {
 		fmt.Printf("[ * ] Output filename: %s\n", config.Output)
 		fmt.Println(isEnabled(config.OnlyVuln), "Save only vulnerable subdomains")

--- a/runner/worker.go
+++ b/runner/worker.go
@@ -46,6 +46,12 @@ func (c *Config) checkSubdomain(subdomain string) Result {
 
 func (c *Config) matchResponse(body string) Result {
 	for _, fingerprint := range c.fingerprints {
+
+		if fingerprint.Fingerprint == "" {
+			// Skip the check if Fingerprint is empty in json file and move to the next. this prevent a scanner to show wrong or false positive result.
+			continue
+		}
+
 		if strings.Contains(body, fingerprint.Fingerprint) {
 			for _, false_positive_string := range fingerprint.False_Positive {
 				if len(string(false_positive_string)) > 0 {


### PR DESCRIPTION
Due to empty fingerprints in the fingerprint.json file, the scan cannot compare accurately and shows false positives or incorrect results.


**Current Version: Latest**
False Positive Output due to error in fingerprints. (Empty Fingerprints)
 
![image](https://github.com/user-attachments/assets/a7eb6586-d68b-403c-83ae-ddbcafcb794c)


After adding fingerprint verification logic in the code:
- It displays the number of fingerprints with empty values (invalid).
- The second line shows the name of the invalid fingerprint to inform the user that this service test will be skipped. To include this scan, add the fingerprints in the fingerprint.json file.
- This will address the issues mentioned in [issue #48](https://github.com/PentestPad/subzy/issues/48).

![image](https://github.com/user-attachments/assets/1f358ce6-e7a5-4060-824d-51466eb6eaa3)